### PR TITLE
UT-1880: Eliminate CDN packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/*
 plugins/*
 node_modules
 __pycache__
+website/assets/libs

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
 		"": {
 			"name": "@uptoolapp/online-3d-viewer",
 			"version": "0.0.7",
+			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
 				"@simonwep/pickr": "1.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 			"dependencies": {
 				"@simonwep/pickr": "1.9.0",
 				"fflate": "0.8.2",
+				"occt-import-js": "^0.0.22",
 				"three": "0.176.0"
 			},
 			"devDependencies": {
@@ -5546,6 +5547,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/occt-import-js": {
+			"version": "0.0.22",
+			"resolved": "https://registry.npmjs.org/occt-import-js/-/occt-import-js-0.0.22.tgz",
+			"integrity": "sha512-pqvP0hJGMgAoFKji+nL+2zIHJ2NJeFTpI2oEEJrVQtvLErDApd2TeAJNhPO9oU+aWUKIUSWoxSfIrF0KisrPtw==",
+			"license": "LGPL-2.1"
 		},
 		"node_modules/omggif": {
 			"version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"website/assets/envmaps/*"
 	],
 	"scripts": {
+		"postinstall": "node -e \"require('fs').cpSync('node_modules/occt-import-js/dist','website/assets/libs/occt-import-js',{recursive:true})\"",
 		"start": "npm run build_website_dev && http-server",
 		"test": "mocha test",
 		"lint": "eslint source",
@@ -77,6 +78,7 @@
 	"dependencies": {
 		"@simonwep/pickr": "1.9.0",
 		"fflate": "0.8.2",
+		"occt-import-js": "^0.0.22",
 		"three": "0.176.0"
 	},
 	"eslintConfig": {

--- a/source/engine/import/importerutils.js
+++ b/source/engine/import/importerutils.js
@@ -1,7 +1,6 @@
 import { IsLower } from '../geometry/geometry.js';
 import { PhongMaterial } from '../model/material.js';
 import { RGBColor, IntegerToHexString } from '../model/color.js';
-import { LoadExternalLibraryFromUrl } from '../io/externallibs.js';
 
 export function NameFromLine (line, startIndex, commentChar)
 {

--- a/source/engine/import/importerutils.js
+++ b/source/engine/import/importerutils.js
@@ -133,13 +133,15 @@ export function CreateOcctWorker (worker)
 
 export function LoadExternalLibrary (libraryName)
 {
-	if (libraryName === 'rhino3dm') {
-		return LoadExternalLibraryFromUrl ('https://cdn.jsdelivr.net/npm/rhino3dm@8.17.0/rhino3dm.min.js');
-	} else if (libraryName === 'webifc') {
-		return LoadExternalLibraryFromUrl ('https://cdn.jsdelivr.net/npm/web-ifc@0.0.68/web-ifc-api-iife.js');
-	} else if (libraryName === 'draco3d') {
-		return LoadExternalLibraryFromUrl ('https://cdn.jsdelivr.net/npm/draco3d@1.5.7/draco_decoder_nodejs.min.js');
-	} else {
-		return null;
-	}
+	// if (libraryName === 'rhino3dm') {
+	// 	return LoadExternalLibraryFromUrl ('https://cdn.jsdelivr.net/npm/rhino3dm@8.17.0/rhino3dm.min.js');
+	// } else if (libraryName === 'webifc') {
+	// 	return LoadExternalLibraryFromUrl ('https://cdn.jsdelivr.net/npm/web-ifc@0.0.68/web-ifc-api-iife.js');
+	// } else if (libraryName === 'draco3d') {
+	// 	return LoadExternalLibraryFromUrl ('https://cdn.jsdelivr.net/npm/draco3d@1.5.7/draco_decoder_nodejs.min.js');
+	// } else {
+	// 	return null;
+	// }
+	// DO NOT IMPORT ANY EXTERNAL library; we don't need the support for these three file formats anyway
+	return null;
 }

--- a/source/engine/import/importerutils.js
+++ b/source/engine/import/importerutils.js
@@ -112,7 +112,7 @@ export function CreateOcctWorker (worker)
 			return;
 		}
 
-		let baseUrl = 'https://cdn.jsdelivr.net/npm/occt-import-js@0.0.22/dist/';
+		let baseUrl = new URL ('assets/libs/occt-import-js/', document.baseURI).href;
 		fetch (baseUrl + 'occt-import-js-worker.js')
 			.then ((response) => {
 				if (!response.ok) {


### PR DESCRIPTION
https://uptool.atlassian.net/browse/UT-1880

tested it locally (from uptool app) by opening a `.stp` file which used to do a request to `cdn.jsdelivr.net` and it's now not doing it anymore.

i tested with this diff

<img width="1831" height="284" alt="Screenshot 2026-04-13 at 11 17 48" src="https://github.com/user-attachments/assets/70ff7166-52ae-48bf-916c-bc4a99ef0323" />

and rebuilding frontend service with

```sh
docker compose build --no-cache --ssh 3d_viewer=.devcontainer/.ssh/3d_viewer_id_ed25519 frontend
```

to pick up my branch when cloning and packing.

when this is merged, i'll create a new tag and update main repo accordingly. similar to https://github.com/uptoolapp/uptool/pull/3250/changes#diff-4444de7e0285ace98379daf14b0a12432671267023fecaa9ce0bc69fb670f8fb but limited to changes in `Dockerfile.frontend` and `frontend/package.json`.